### PR TITLE
Add perfil editing modal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Exemplo de configuracao do banco de dados
+DB_HOST=localhost
+DB_NAME=fazendinha
+DB_USER=seu_usuario
+DB_PASS=sua_senha

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Ignore PHP configuration with credentials
+config.php
+.env
+
+# Ignore uploaded files
+uploads/
+backend/uploads/
+
+# Ignore vendor folder if using composer
+vendor/
+
+# Ignore OS files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Projeto Fazendinha
+
+Este projeto é uma aplicação web simples em PHP para gerenciamento de perfis, empresas e logins.
+
+## Requisitos
+- PHP 7.4 ou superior
+- Servidor web (Apache, Nginx ou similar)
+- MySQL ou MariaDB
+
+## Configuração
+1. Copie o arquivo `.env.example` para `.env` e ajuste com as credenciais do banco de dados.
+   ```bash
+   cp .env.example .env
+   # Edite o arquivo .env para colocar usuario e senha
+   ```
+2. Importe o esquema de banco de dados correspondente (não incluído neste repositório).
+3. Certifique-se de que a pasta `uploads/` tenha permissões de escrita caso utilize upload de arquivos.
+4. Inicie o servidor web apontando para o diretório do projeto.
+
+## Uso
+O arquivo `index.php` redireciona para `pages/login.php`, onde é possível realizar o login. Após a autenticação, o usuário é encaminhado para o painel correspondente à sua categoria (Admin, Cadastrar ou Fazendeiro).
+
+## Segurança
+- As credenciais do banco de dados são carregadas do arquivo `.env` ou de variáveis de ambiente.
+- Recomenda-se manter o arquivo `.env` fora do controle de versão (já incluído no `.gitignore`).
+

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -7,6 +7,30 @@ body {
     color: #5d4037;
 }
 
+.tabs {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 20px;
+    gap: 10px;
+}
+
+.tab-link {
+    padding: 10px 20px;
+    background-color: #d4e4d2;
+    border: 1px solid #8bc34a;
+    border-radius: 5px 5px 0 0;
+    cursor: pointer;
+    color: #5d4037;
+}
+
+.tab-link.active {
+    background-color: #8bc34a;
+    color: #fff;
+}
+
+.tab-content {
+    display: none;
+}
 header {
     background-color: #d4e4d2;
     padding: 10px 20px;
@@ -230,6 +254,19 @@ button[type="submit"]:hover {
     border-radius: 10px;
     padding: 20px;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+.filter-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 15px;
+}
+
+.filter-group input,
+.filter-group select {
+    flex: 1;
+    min-width: 150px;
 }
 
 table {

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -133,6 +133,7 @@ function loadData() {
             updateListaPerfis();
             updateListaLogins();
             updateDashboard();
+            updateCharts();
         })
         .catch(error => {
             console.error('Erro ao carregar dados:', error);
@@ -168,7 +169,21 @@ function updateListaPerfis() {
         tbody.innerHTML = '';
         console.log('Perfis recebidos:', perfis);
 
-        const perfisCriados = perfis.filter(perfil => perfil.perfil_criado);
+        const nomeFiltro = (document.getElementById('filtro-nome')?.value || '').toLowerCase();
+        const googleFiltro = document.getElementById('filtro-google')?.value || '';
+        const statusFiltro = document.getElementById('filtro-status')?.value || '';
+        const contaFiltro = document.getElementById('filtro-conta')?.value || '';
+        const estadoFiltro = document.getElementById('filtro-estado')?.value || '';
+
+        const perfisCriados = perfis.filter(perfil => perfil.perfil_criado).filter(perfil => {
+            const nome = (perfil.nome_perfil || '').toLowerCase();
+            if (nomeFiltro && !nome.includes(nomeFiltro)) return false;
+            if (googleFiltro && perfil.google_aprovado !== googleFiltro) return false;
+            if (statusFiltro && perfil.status !== statusFiltro) return false;
+            if (contaFiltro && perfil.conta_suspensa !== contaFiltro) return false;
+            if (estadoFiltro && perfil.estado !== estadoFiltro) return false;
+            return true;
+        });
 
         const labels = [
             'Nome do Perfil',
@@ -198,7 +213,9 @@ function updateListaPerfis() {
                 <td data-label="${labels[9]}">${perfil.ultimo_evento || '-'}</td>
             `;
             row.style.cursor = 'pointer';
-            row.addEventListener('click', () => {
+            row.addEventListener('click', () => openEditPerfilModal(perfil));
+            row.addEventListener('dblclick', (e) => {
+                e.stopPropagation();
                 window.location.href = `eventos.php?perfil_id=${perfil.id}`;
             });
             tbody.appendChild(row);
@@ -224,6 +241,99 @@ function updateListaLogins() {
     }
 }
 
+let pagamentos = [];
+function loadPagamentos() {
+    fetch('../backend/get_pagamentos.php')
+        .then(response => {
+            if (!response.ok) throw new Error('Erro na resposta do servidor: ' + response.statusText);
+            return response.json();
+        })
+        .then(data => {
+            pagamentos = data.pagamentos || [];
+            updateTabelaPagamentos();
+        })
+        .catch(error => {
+            console.error('Erro ao carregar pagamentos:', error);
+            showMessageBox('Erro ao carregar pagamentos: ' + error.message, 'error');
+        });
+}
+
+let proximosPagamentos = [];
+function loadProximosPagamentos() {
+    fetch('../backend/get_pagamentos.php?proximos=1')
+        .then(response => {
+            if (!response.ok) throw new Error('Erro na resposta do servidor: ' + response.statusText);
+            return response.json();
+        })
+        .then(data => {
+            proximosPagamentos = data.pagamentos || [];
+            updateTabelaProximos();
+        })
+        .catch(error => {
+            console.error('Erro ao carregar próximos pagamentos:', error);
+            showMessageBox('Erro ao carregar próximos pagamentos: ' + error.message, 'error');
+        });
+}
+
+function updateTabelaPagamentos() {
+    const tbody = document.querySelector('#tabela-pagamentos tbody');
+    if (tbody) {
+        tbody.innerHTML = '';
+        pagamentos.forEach(p => {
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td>${p.descricao || '-'}</td>
+                <td>${p.valor ? parseFloat(p.valor).toFixed(2) : '-'}</td>
+                <td>${p.tipo || '-'}</td>
+                <td>${p.data_vencimento || '-'}</td>
+                <td>${p.data_pagamento || '-'}</td>
+                <td>${p.status || '-'}</td>
+            `;
+            tbody.appendChild(row);
+        });
+    }
+}
+
+function updateTabelaProximos() {
+    const tbody = document.querySelector('#tabela-proximos tbody');
+    if (tbody) {
+        tbody.innerHTML = '';
+        proximosPagamentos.forEach(p => {
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td>${p.descricao || '-'}</td>
+                <td>${p.valor ? parseFloat(p.valor).toFixed(2) : '-'}</td>
+                <td>${p.tipo || '-'}</td>
+                <td>${p.data_vencimento || '-'}</td>
+                <td>${p.status || '-'}</td>
+            `;
+            tbody.appendChild(row);
+        });
+    }
+}
+
+function cadastrarPagamento(event) {
+    event.preventDefault();
+    const form = event.target;
+    const formData = new FormData(form);
+    fetch('../backend/save_pagamento.php', { method: 'POST', body: formData })
+        .then(response => {
+            if (!response.ok) throw new Error('Erro na resposta do servidor: ' + response.statusText);
+            return response.json();
+        })
+        .then(data => {
+            showMessageBox(data.message, data.status);
+            if (data.status === 'success') {
+                form.reset();
+                loadPagamentos();
+            }
+        })
+        .catch(error => {
+            console.error('Erro ao cadastrar pagamento:', error);
+            showMessageBox('Erro ao cadastrar pagamento: ' + error.message, 'error');
+        });
+}
+
 function updateDashboard() {
     const perfilCriadoEl = document.getElementById('perfil-criado');
     const googleAprovadoEl = document.getElementById('google-aprovado');
@@ -240,6 +350,52 @@ function updateDashboard() {
     if (empresasDisponiveisEl) empresasDisponiveisEl.textContent = empresasDisponiveis;
     if (pessoasDisponiveisEl) pessoasDisponiveisEl.textContent = pessoasDisponiveis;
     if (emailsDisponiveisEl) emailsDisponiveisEl.textContent = emailsDisponiveis;
+}
+
+let graficoRecursos;
+function updateCharts() {
+    const totalEmpresas = empresas.length;
+    const totalPessoas = pessoas.length;
+    const totalEmails = emails.length;
+
+    const usadosEmpresas = totalEmpresas - empresasDisponiveis;
+    const usadosPessoas = totalPessoas - pessoasDisponiveis;
+    const usadosEmails = totalEmails - emailsDisponiveis;
+
+    const dados = {
+        labels: ['Empresas', 'Pessoas', 'Emails'],
+        datasets: [
+            {
+                label: 'Disponíveis',
+                backgroundColor: '#8bc34a',
+                data: [empresasDisponiveis, pessoasDisponiveis, emailsDisponiveis]
+            },
+            {
+                label: 'Usados',
+                backgroundColor: '#ff9800',
+                data: [usadosEmpresas, usadosPessoas, usadosEmails]
+            }
+        ]
+    };
+
+    if (graficoRecursos) {
+        graficoRecursos.data = dados;
+        graficoRecursos.update();
+    } else if (document.getElementById('grafico-recursos')) {
+        const ctx = document.getElementById('grafico-recursos').getContext('2d');
+        graficoRecursos = new Chart(ctx, {
+            type: 'bar',
+            data: dados,
+            options: {
+                responsive: true,
+                scales: {
+                    y: {
+                        beginAtZero: true
+                    }
+                }
+            }
+        });
+    }
 }
 
 function toggleCnpj() {
@@ -322,6 +478,20 @@ function openEditLoginModal(id, nome_site, url, login, senha) {
     }
 }
 
+function openEditPerfilModal(perfil) {
+    const form = document.getElementById('form-edit-perfil');
+    if (form) {
+        form.querySelector('#perfil-id').value = perfil.id || '';
+        form.querySelector('#perfil-google').value = perfil.google_aprovado || '';
+        form.querySelector('#perfil-campanhas').value = perfil.campanhas || '';
+        form.querySelector('#perfil-suspensa').value = perfil.conta_suspensa || '';
+        form.querySelector('#perfil-estado').value = perfil.estado || '';
+        form.querySelector('#perfil-status').value = perfil.status || '';
+        form.querySelector('#perfil-objetivo').value = perfil.objetivo || '';
+        openModal('modal-edit-perfil');
+    }
+}
+
 function saveEditedItem(event, type) {
     event.preventDefault();
     event.stopPropagation();
@@ -362,6 +532,34 @@ function saveEditedItem(event, type) {
     .catch(error => {
         console.error('Erro ao salvar item:', error);
         showMessageBox('Erro ao salvar item: ' + error.message, 'error');
+    });
+}
+
+function savePerfilEdit(event) {
+    event.preventDefault();
+    const form = event.target;
+    const formData = new FormData(form);
+
+    fetch('../backend/edit_perfil.php', {
+        method: 'POST',
+        body: formData
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Erro na resposta do servidor: ' + response.statusText);
+        }
+        return response.json();
+    })
+    .then(data => {
+        showMessageBox(data.message, data.status);
+        if (data.status === 'success') {
+            closeModal('modal-edit-perfil');
+            loadData();
+        }
+    })
+    .catch(error => {
+        console.error('Erro ao salvar perfil:', error);
+        showMessageBox('Erro ao salvar perfil: ' + error.message, 'error');
     });
 }
 
@@ -415,6 +613,26 @@ function copiarTexto(button) {
     });
 }
 
+function openAdminTab(tab) {
+    const tabs = ['gerenciamento', 'graficos', 'pagamentos', 'proximos'];
+    tabs.forEach(t => {
+        const content = document.getElementById(`tab-${t}`);
+        const link = document.querySelector(`.tab-link[data-tab="${t}"]`);
+        if (content) content.style.display = t === tab ? 'block' : 'none';
+        if (link) {
+            if (t === tab) link.classList.add('active');
+            else link.classList.remove('active');
+        }
+    });
+    if (tab === 'graficos') {
+        updateCharts();
+    } else if (tab === 'pagamentos') {
+        loadPagamentos();
+    } else if (tab === 'proximos') {
+        loadProximosPagamentos();
+    }
+}
+
 function toggleLoginDetails(titleElement) {
     const details = titleElement.nextElementSibling;
     if (details.style.display === 'none' || details.style.display === '') {
@@ -429,4 +647,21 @@ function toggleLoginDetails(titleElement) {
 window.onload = function() {
     loadData();
     updateTime();
+    if (typeof openAdminTab === 'function') {
+        openAdminTab('gerenciamento');
+    }
+
+    const formPag = document.getElementById('form-pagamento');
+    if (formPag) formPag.addEventListener('submit', cadastrarPagamento);
+
+    const formEditPerfil = document.getElementById('form-edit-perfil');
+    if (formEditPerfil) formEditPerfil.addEventListener('submit', savePerfilEdit);
+
+    const nomeInput = document.getElementById('filtro-nome');
+    if (nomeInput) nomeInput.addEventListener('input', updateListaPerfis);
+
+    ['filtro-google', 'filtro-status', 'filtro-conta', 'filtro-estado'].forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.addEventListener('change', updateListaPerfis);
+    });
 };

--- a/backend/edit_perfil.php
+++ b/backend/edit_perfil.php
@@ -1,0 +1,39 @@
+<?php
+session_start();
+require_once '../config.php';
+
+if (!isset($_SESSION['categoria']) || $_SESSION['categoria'] !== 'Fazendeiro') {
+    echo json_encode(['status' => 'error', 'message' => 'Acesso não autorizado']);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT);
+    $google = trim(filter_input(INPUT_POST, 'google_aprovado', FILTER_SANITIZE_STRING));
+    $campanhas = trim(filter_input(INPUT_POST, 'campanhas', FILTER_SANITIZE_STRING));
+    $suspensa = trim(filter_input(INPUT_POST, 'conta_suspensa', FILTER_SANITIZE_STRING));
+    $estado = trim(filter_input(INPUT_POST, 'estado', FILTER_SANITIZE_STRING));
+    $status = trim(filter_input(INPUT_POST, 'status', FILTER_SANITIZE_STRING));
+    $objetivo = trim(filter_input(INPUT_POST, 'objetivo', FILTER_SANITIZE_STRING));
+
+    if (!$id) {
+        echo json_encode(['status' => 'error', 'message' => 'ID inválido']);
+        exit;
+    }
+
+    $stmt = $conn->prepare("UPDATE perfis SET google_aprovado=?, campanhas=?, conta_suspensa=?, estado=?, status=?, objetivo=? WHERE id=?");
+    $stmt->bind_param("ssssssi", $google, $campanhas, $suspensa, $estado, $status, $objetivo, $id);
+
+    if ($stmt->execute()) {
+        echo json_encode(['status' => 'success', 'message' => 'Perfil atualizado com sucesso!']);
+    } else {
+        echo json_encode(['status' => 'error', 'message' => 'Erro ao atualizar perfil: ' . $stmt->error]);
+    }
+
+    $stmt->close();
+    $conn->close();
+} else {
+    echo json_encode(['status' => 'error', 'message' => 'Método não permitido']);
+}
+?>
+

--- a/backend/get_pagamentos.php
+++ b/backend/get_pagamentos.php
@@ -1,0 +1,22 @@
+<?php
+session_start();
+require_once '../config.php';
+
+if (!isset($_SESSION['categoria']) || $_SESSION['categoria'] !== 'Admin') {
+    echo json_encode(['success' => false, 'message' => 'Acesso não autorizado']);
+    exit;
+}
+
+$apenasProximos = isset($_GET['proximos']);
+$query = "SELECT * FROM pagamentos";
+if ($apenasProximos) {
+    $query .= " WHERE data_vencimento >= CURDATE() ORDER BY data_vencimento ASC";
+} else {
+    $query .= " ORDER BY data_vencimento DESC";
+}
+$result = $conn->query($query);
+$pagamentos = $result ? $result->fetch_all(MYSQLI_ASSOC) : [];
+
+echo json_encode(['success' => true, 'pagamentos' => $pagamentos]);
+$conn->close();
+?>

--- a/backend/save_pagamento.php
+++ b/backend/save_pagamento.php
@@ -1,0 +1,37 @@
+<?php
+session_start();
+require_once '../config.php';
+
+if (!isset($_SESSION['categoria']) || $_SESSION['categoria'] !== 'Admin') {
+    echo json_encode(['status' => 'error', 'message' => 'Acesso não autorizado']);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $descricao = trim(filter_input(INPUT_POST, 'descricao', FILTER_SANITIZE_STRING));
+    $valor = filter_input(INPUT_POST, 'valor', FILTER_VALIDATE_FLOAT);
+    $data_vencimento = trim(filter_input(INPUT_POST, 'data_vencimento', FILTER_SANITIZE_STRING));
+    $data_pagamento = trim(filter_input(INPUT_POST, 'data_pagamento', FILTER_SANITIZE_STRING));
+    $tipo = trim(filter_input(INPUT_POST, 'tipo', FILTER_SANITIZE_STRING));
+    $status = trim(filter_input(INPUT_POST, 'status', FILTER_SANITIZE_STRING));
+
+    if (empty($descricao) || $valor === false || empty($data_vencimento) || empty($status) || empty($tipo)) {
+        echo json_encode(['status' => 'error', 'message' => 'Campos obrigat\xc3\xb3rios n\xc3\xa3o preenchidos']);
+        exit;
+    }
+
+    $stmt = $conn->prepare("INSERT INTO pagamentos (descricao, valor, tipo, data_vencimento, data_pagamento, status) VALUES (?, ?, ?, ?, ?, ?)");
+    $stmt->bind_param("sdssss", $descricao, $valor, $tipo, $data_vencimento, $data_pagamento, $status);
+
+    if ($stmt->execute()) {
+        echo json_encode(['status' => 'success', 'message' => 'Pagamento cadastrado com sucesso!']);
+    } else {
+        echo json_encode(['status' => 'error', 'message' => 'Erro ao cadastrar pagamento: ' . $stmt->error]);
+    }
+
+    $stmt->close();
+    $conn->close();
+} else {
+    echo json_encode(['status' => 'error', 'message' => 'M\xc3\xa9todo n\xc3\xa3o permitido']);
+}
+?>

--- a/config.php
+++ b/config.php
@@ -1,8 +1,20 @@
 <?php
-$host = 'localhost';
-$dbname = 'fazendinha';
-$username = 'th2k';
-$password = 'Passuordi123';
+// Carrega variaveis de ambiente a partir de um arquivo .env se existir
+$envFile = __DIR__ . '/.env';
+if (file_exists($envFile)) {
+    $lines = file($envFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    foreach ($lines as $line) {
+        if (strpos(trim($line), '#') === 0) continue;
+        list($key, $value) = array_map('trim', explode('=', $line, 2));
+        putenv(sprintf('%s=%s', $key, $value));
+        $_ENV[$key] = $value;
+    }
+}
+
+$host = getenv('DB_HOST') ?: 'localhost';
+$dbname = getenv('DB_NAME') ?: 'fazendinha';
+$username = getenv('DB_USER') ?: 'usuario';
+$password = getenv('DB_PASS') ?: 'senha';
 
 try {
     $conn = new mysqli($host, $username, $password, $dbname);

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,4 +1,5 @@
 </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="../assets/js/script.js"></script>
 </body>
 </html>

--- a/pages/dashboard_admin.php
+++ b/pages/dashboard_admin.php
@@ -187,6 +187,16 @@ $colunas_perfil = [
     <button onclick="closeMessageBox()">Fechar</button>
 </div>
 
+<!-- Abas do Dashboard -->
+<div class="tabs">
+    <button class="tab-link active" data-tab="gerenciamento" onclick="openAdminTab('gerenciamento')">Gerenciamento</button>
+    <button class="tab-link" data-tab="graficos" onclick="openAdminTab('graficos')">Gráficos</button>
+    <button class="tab-link" data-tab="pagamentos" onclick="openAdminTab('pagamentos')">Pagamentos</button>
+    <button class="tab-link" data-tab="proximos" onclick="openAdminTab('proximos')">Próximos Pagamentos</button>
+</div>
+
+<div id="tab-gerenciamento" class="tab-content" style="display: block;">
+
 <!-- Botões Principais -->
 <div class="button-group">
     <button onclick="openModal('modal-add-info')" class="btn destaque">+ Add Informações</button>
@@ -605,6 +615,80 @@ $colunas_perfil = [
                 <th>Status</th>
                 <th>Objetivo</th>
                 <th>Último Evento</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+
+</div><!-- fim tab-gerenciamento -->
+
+<div id="tab-graficos" class="tab-content">
+    <h2>Gráficos de Utilização</h2>
+    <canvas id="grafico-recursos" width="600" height="300"></canvas>
+</div>
+
+<div id="tab-pagamentos" class="tab-content">
+    <h2>Cadastro de Pagamentos</h2>
+    <form id="form-pagamento" onsubmit="cadastrarPagamento(event)">
+        <div class="form-row">
+            <label for="descricao_pag">Descrição:</label>
+            <input type="text" id="descricao_pag" name="descricao" required>
+        </div>
+        <div class="form-row">
+            <label for="valor_pag">Valor:</label>
+            <input type="number" step="0.01" id="valor_pag" name="valor" required>
+        </div>
+        <div class="form-row">
+            <label for="venc_pag">Data de Vencimento:</label>
+            <input type="date" id="venc_pag" name="data_vencimento" required>
+        </div>
+        <div class="form-row">
+            <label for="pag_pag">Data de Pagamento:</label>
+            <input type="date" id="pag_pag" name="data_pagamento">
+        </div>
+        <div class="form-row">
+            <label for="tipo_pag">Tipo de Pagamento:</label>
+            <select id="tipo_pag" name="tipo" required>
+                <option value="Unico">Único</option>
+                <option value="Mensal">Mensal</option>
+                <option value="Anual">Anual</option>
+            </select>
+        </div>
+        <div class="form-row">
+            <label for="status_pag">Status:</label>
+            <select id="status_pag" name="status" required>
+                <option value="Pendente">Pendente</option>
+                <option value="Pago">Pago</option>
+            </select>
+        </div>
+        <button type="submit">Salvar</button>
+    </form>
+    <table id="tabela-pagamentos">
+        <thead>
+            <tr>
+                <th>Descrição</th>
+                <th>Valor</th>
+                <th>Tipo</th>
+                <th>Vencimento</th>
+                <th>Pagamento</th>
+                <th>Status</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+
+<div id="tab-proximos" class="tab-content">
+    <h2>Próximos Pagamentos</h2>
+    <table id="tabela-proximos">
+        <thead>
+            <tr>
+                <th>Descrição</th>
+                <th>Valor</th>
+                <th>Tipo</th>
+                <th>Vencimento</th>
+                <th>Status</th>
             </tr>
         </thead>
         <tbody></tbody>

--- a/pages/dashboard_fazendeiro.php
+++ b/pages/dashboard_fazendeiro.php
@@ -77,9 +77,70 @@ $emails = $conn->query("SELECT id, email FROM emails WHERE id NOT IN (SELECT ema
     </div>
 </div>
 
+<!-- Modal Editar Perfil -->
+<div id="modal-edit-perfil" class="modal">
+    <div class="modal-content">
+        <span class="close" onclick="closeModal('modal-edit-perfil')">×</span>
+        <h2>Editar Perfil</h2>
+        <form id="form-edit-perfil">
+            <input type="hidden" name="id" id="perfil-id">
+            <label>Google Aprovado:</label>
+            <select name="google_aprovado" id="perfil-google">
+                <option value="Aprovado">Aprovado</option>
+                <option value="Pendente">Pendente</option>
+            </select>
+            <label>Campanhas:</label>
+            <input type="text" name="campanhas" id="perfil-campanhas">
+            <label>Conta Suspensa:</label>
+            <select name="conta_suspensa" id="perfil-suspensa">
+                <option value="Sim">Sim</option>
+                <option value="Não">Não</option>
+            </select>
+            <label>Estado:</label>
+            <select name="estado" id="perfil-estado">
+                <option value="Aguardando">Aguardando</option>
+                <option value="Rodando">Rodando</option>
+                <option value="Pausado">Pausado</option>
+            </select>
+            <label>Status:</label>
+            <select name="status" id="perfil-status">
+                <option value="Ativa">Ativa</option>
+                <option value="Inativa">Inativa</option>
+            </select>
+            <label>Objetivo:</label>
+            <input type="text" name="objetivo" id="perfil-objetivo">
+            <button type="submit">Salvar</button>
+        </form>
+    </div>
+</div>
+
 <!-- Lista de Perfis -->
 <div class="lista-perfis">
     <h2>Lista de Perfis</h2>
+    <div class="filter-group">
+        <input type="text" id="filtro-nome" placeholder="Buscar nome">
+        <select id="filtro-google">
+            <option value="">Google Aprovado</option>
+            <option value="Aprovado">Aprovado</option>
+            <option value="Pendente">Pendente</option>
+        </select>
+        <select id="filtro-status">
+            <option value="">Status</option>
+            <option value="Ativa">Ativa</option>
+            <option value="Inativa">Inativa</option>
+        </select>
+        <select id="filtro-conta">
+            <option value="">Conta Suspensa</option>
+            <option value="Sim">Sim</option>
+            <option value="Não">Não</option>
+        </select>
+        <select id="filtro-estado">
+            <option value="">Estado</option>
+            <option value="Aguardando">Aguardando</option>
+            <option value="Rodando">Rodando</option>
+            <option value="Pausado">Pausado</option>
+        </select>
+    </div>
     <table id="tabela-perfis">
         <thead>
             <tr>

--- a/pages/login.php
+++ b/pages/login.php
@@ -2,6 +2,11 @@
 session_start();
 require_once '../config.php';
 
+// Gera token CSRF se ainda não existir
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
 if (isset($_SESSION['user_id'])) {
     if ($_SESSION['categoria'] === 'Admin') {
         header("Location: dashboard_admin.php");
@@ -14,38 +19,44 @@ if (isset($_SESSION['user_id'])) {
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $usuario = trim(filter_input(INPUT_POST, 'usuario', FILTER_SANITIZE_STRING));
-    $senha = $_POST['senha'];
-
-    if (empty($usuario) || empty($senha)) {
-        $erro = "Usuário e senha são obrigatórios.";
+    // Verifica token CSRF
+    $postedToken = $_POST['csrf_token'] ?? '';
+    if (!hash_equals($_SESSION['csrf_token'], $postedToken)) {
+        $erro = 'Token CSRF inválido.';
     } else {
-        $stmt = $conn->prepare("SELECT id, nome, categoria, senha FROM users WHERE usuario = ?");
-        $stmt->bind_param("s", $usuario);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $user = $result->fetch_assoc();
+        $usuario = trim(filter_input(INPUT_POST, 'usuario', FILTER_SANITIZE_STRING));
+        $senha = $_POST['senha'];
 
-        if ($user && password_verify($senha, $user['senha'])) {
-            $_SESSION['user_id'] = $user['id'];
-            $_SESSION['nome'] = $user['nome'];
-            $_SESSION['categoria'] = $user['categoria'];
-
-            if ($user['categoria'] === 'Admin') {
-                header("Location: dashboard_admin.php");
-            } elseif ($user['categoria'] === 'Cadastrar') {
-                header("Location: dashboard_cadastrar.php");
-            } elseif ($_SESSION['categoria'] === 'Fazendeiro') {
-                header("Location: dashboard_fazendeiro.php");
-            }
-            exit;
+        if (empty($usuario) || empty($senha)) {
+            $erro = "Usuário e senha são obrigatórios.";
         } else {
-            $erro = "Usuário ou senha incorretos.";
-        }
+            $stmt = $conn->prepare("SELECT id, nome, categoria, senha FROM users WHERE usuario = ?");
+            $stmt->bind_param("s", $usuario);
+            $stmt->execute();
+            $result = $stmt->get_result();
+            $user = $result->fetch_assoc();
 
-        $stmt->close();
+            if ($user && password_verify($senha, $user['senha'])) {
+                $_SESSION['user_id'] = $user['id'];
+                $_SESSION['nome'] = $user['nome'];
+                $_SESSION['categoria'] = $user['categoria'];
+
+                if ($user['categoria'] === 'Admin') {
+                    header("Location: dashboard_admin.php");
+                } elseif ($user['categoria'] === 'Cadastrar') {
+                    header("Location: dashboard_cadastrar.php");
+                } elseif ($_SESSION['categoria'] === 'Fazendeiro') {
+                    header("Location: dashboard_fazendeiro.php");
+                }
+                exit;
+            } else {
+                $erro = "Usuário ou senha incorretos.";
+            }
+
+            $stmt->close();
+        }
+        $conn->close();
     }
-    $conn->close();
 }
 ?>
 
@@ -63,6 +74,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <h2>Login</h2>
         <?php if (isset($erro)) echo "<p class='error'>" . htmlspecialchars($erro, ENT_QUOTES, 'UTF-8') . "</p>"; ?>
         <form method="POST" action="">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token'], ENT_QUOTES, 'UTF-8'); ?>">
             <input type="text" name="usuario" placeholder="Usuário" required autocomplete="username">
             <input type="password" name="senha" placeholder="Senha" required autocomplete="current-password">
             <button type="submit">Entrar</button>


### PR DESCRIPTION
## Summary
- add modal in farmer dashboard for editing perfis
- update profile list interactions to open edit modal
- implement `edit_perfil.php` backend endpoint
- wire up JavaScript to handle editing and saving

## Testing
- `node --check assets/js/script.js`
- ❌ `php -l backend/edit_perfil.php` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471389d8208333a5db99e6277cbe80